### PR TITLE
wp-9018 maintain column order

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -307,7 +307,8 @@ def desired_columns(selected, table_schema):
             'Columns %s are primary keys but were not selected. Adding them.',
             not_selected_but_automatic)
 
-    return selected.intersection(available).union(automatic)
+    return sorted(selected.intersection(available).union(automatic), key = list(table_schema.properties.keys()).index)
+
 
 
 def log_engine(mysql_conn, catalog_entry):


### PR DESCRIPTION
## Problem
Import doesn't maintain original columns' order and the columns' order changed on different runs, which causing issues for refreshing and creating app via recommendation.
Jira: https://varicent.atlassian.net/browse/WP-9018
## Proposed changes
using the schema order to maintain the column order
will create tag v1.17.6