### PR TITLE
WP-21726 upgrade major version for python upgrade 3.8+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mysql"
-version = "1.18.0"
+version = "2.0.0"
 description = "Singer.io tap for extracting data from MySQL"
 authors = ["Stitch"]
 classifiers = ['Programming Language :: Python :: 3 :: Only']


### PR DESCRIPTION
Changes in prev pr (https://github.com/symon-ai/tap-mysql/pull/15): (forgot to bump major version)
- upgrades on packages for security
- upgrade to python 3.8+

Changes in this pr:
- increase major version